### PR TITLE
[crt][fuzzer] Allow variable-length TORCW mutations

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDictionary.h
+++ b/compiler-rt/lib/fuzzer/FuzzerDictionary.h
@@ -48,15 +48,23 @@ private:
 
 typedef FixedWord<64> Word;
 
+struct PositionHint {
+  size_t Idx;
+  size_t Size;
+};
+
 class DictionaryEntry {
  public:
   DictionaryEntry() {}
   DictionaryEntry(Word W) : W(W) {}
-  DictionaryEntry(Word W, size_t PositionHint) : W(W), PositionHint(PositionHint) {}
+  DictionaryEntry(Word W, PositionHint PositionHint)
+      : W(W), PositionHint(PositionHint) {}
   const Word &GetW() const { return W; }
 
-  bool HasPositionHint() const { return PositionHint != std::numeric_limits<size_t>::max(); }
-  size_t GetPositionHint() const {
+  bool HasPositionHint() const {
+    return PositionHint.Idx != std::numeric_limits<size_t>::max();
+  }
+  PositionHint GetPositionHint() const {
     assert(HasPositionHint());
     return PositionHint;
   }
@@ -68,13 +76,14 @@ class DictionaryEntry {
   void Print(const char *PrintAfter = "\n") {
     PrintASCII(W.data(), W.size());
     if (HasPositionHint())
-      Printf("@%zd", GetPositionHint());
+      Printf("@%zd-%zd", GetPositionHint().Idx,
+             GetPositionHint().Idx + GetPositionHint().Size);
     Printf("%s", PrintAfter);
   }
 
 private:
   Word W;
-  size_t PositionHint = std::numeric_limits<size_t>::max();
+  PositionHint PositionHint = {std::numeric_limits<size_t>::max(), 0};
   size_t UseCount = 0;
   size_t SuccessCount = 0;
 };

--- a/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
@@ -184,21 +184,27 @@ size_t MutationDispatcher::ApplyDictionaryEntry(uint8_t *Data, size_t Size,
                                                 size_t MaxSize,
                                                 DictionaryEntry &DE) {
   const Word &W = DE.GetW();
-  bool UsePositionHint = DE.HasPositionHint() &&
-                         DE.GetPositionHint() + W.size() < Size &&
-                         Rand.RandBool();
-  if (Rand.RandBool()) {  // Insert W.
-    if (Size + W.size() > MaxSize) return 0;
-    size_t Idx = UsePositionHint ? DE.GetPositionHint() : Rand(Size + 1);
-    memmove(Data + Idx + W.size(), Data + Idx, Size - Idx);
-    memcpy(Data + Idx, W.data(), W.size());
-    Size += W.size();
-  } else {  // Overwrite some bytes with W.
-    if (W.size() > Size) return 0;
-    size_t Idx = UsePositionHint ? DE.GetPositionHint() : Rand(Size - W.size());
-    memcpy(Data + Idx, W.data(), W.size());
-  }
-  return Size;
+  bool UsePositionHint =
+      DE.HasPositionHint() &&
+      DE.GetPositionHint().Idx + DE.GetPositionHint().Size < Size &&
+      Rand.RandBool();
+  // Either insert W or overwrite some bytes with it using a size hint if
+  // possible.
+  size_t HintSize =
+      Rand.RandBool()
+          ? 0
+          : (UsePositionHint ? DE.GetPositionHint().Size : W.size());
+  if (HintSize > Size)
+    return 0;
+  size_t Idx =
+      UsePositionHint ? DE.GetPositionHint().Idx : Rand(Size + 1 - HintSize);
+  if (Size + W.size() - HintSize > MaxSize)
+    return 0;
+  // Overwrite HintSize bytes at Idx with W (HintSize == 0 corresponds to
+  // insertion).
+  memmove(Data + Idx + W.size(), Data + Idx + HintSize, Size - Idx - HintSize);
+  memcpy(Data + Idx, W.data(), W.size());
+  return Size + W.size() - HintSize;
 }
 
 // Somewhere in the past we have observed a comparison instructions
@@ -208,28 +214,31 @@ size_t MutationDispatcher::ApplyDictionaryEntry(uint8_t *Data, size_t Size,
 // input and if it succeeds it creates a DE with a position hint.
 // Otherwise it creates a DE with one of the arguments w/o a position hint.
 DictionaryEntry MutationDispatcher::MakeDictionaryEntryFromCMP(
-    const void *Arg1, const void *Arg2,
-    const void *Arg1Mutation, const void *Arg2Mutation,
-    size_t ArgSize, const uint8_t *Data,
-    size_t Size) {
+    const void *Arg1, const void *Arg2, const void *Arg1Mutation,
+    const void *Arg2Mutation, size_t Arg1Size, size_t Arg2Size,
+    const uint8_t *Data, size_t Size) {
   bool HandleFirst = Rand.RandBool();
   const void *ExistingBytes, *DesiredBytes;
+  size_t ExistingSize, DesiredSize;
   Word W;
   const uint8_t *End = Data + Size;
   for (int Arg = 0; Arg < 2; Arg++) {
     ExistingBytes = HandleFirst ? Arg1 : Arg2;
+    ExistingSize = HandleFirst ? Arg1Size : Arg2Size;
     DesiredBytes = HandleFirst ? Arg2Mutation : Arg1Mutation;
+    DesiredSize = HandleFirst ? Arg2Size : Arg1Size;
     HandleFirst = !HandleFirst;
-    W.Set(reinterpret_cast<const uint8_t*>(DesiredBytes), ArgSize);
+    W.Set(reinterpret_cast<const uint8_t *>(DesiredBytes), DesiredSize);
     const size_t kMaxNumPositions = 8;
-    size_t Positions[kMaxNumPositions];
+    PositionHint Positions[kMaxNumPositions];
     size_t NumPositions = 0;
     for (const uint8_t *Cur = Data;
          Cur < End && NumPositions < kMaxNumPositions; Cur++) {
-      Cur =
-          (const uint8_t *)SearchMemory(Cur, End - Cur, ExistingBytes, ArgSize);
+      Cur = (const uint8_t *)SearchMemory(Cur, End - Cur, ExistingBytes,
+                                          ExistingSize);
       if (!Cur) break;
-      Positions[NumPositions++] = Cur - Data;
+      Positions[NumPositions++] = {static_cast<size_t>(Cur - Data),
+                                   ExistingSize};
     }
     if (!NumPositions) continue;
     return DictionaryEntry(W, Positions[Rand(NumPositions)]);
@@ -237,7 +246,6 @@ DictionaryEntry MutationDispatcher::MakeDictionaryEntryFromCMP(
   DictionaryEntry DE(W);
   return DE;
 }
-
 
 template <class T>
 DictionaryEntry MutationDispatcher::MakeDictionaryEntryFromCMP(
@@ -247,13 +255,14 @@ DictionaryEntry MutationDispatcher::MakeDictionaryEntryFromCMP(
   T Arg1Mutation = static_cast<T>(Arg1 + Rand(-1, 1));
   T Arg2Mutation = static_cast<T>(Arg2 + Rand(-1, 1));
   return MakeDictionaryEntryFromCMP(&Arg1, &Arg2, &Arg1Mutation, &Arg2Mutation,
-                                    sizeof(Arg1), Data, Size);
+                                    sizeof(Arg1), sizeof(Arg2), Data, Size);
 }
 
 DictionaryEntry MutationDispatcher::MakeDictionaryEntryFromCMP(
     const Word &Arg1, const Word &Arg2, const uint8_t *Data, size_t Size) {
   return MakeDictionaryEntryFromCMP(Arg1.data(), Arg2.data(), Arg1.data(),
-                                    Arg2.data(), Arg1.size(), Data, Size);
+                                    Arg2.data(), Arg1.size(), Arg2.size(), Data,
+                                    Size);
 }
 
 size_t MutationDispatcher::Mutate_AddWordFromTORC(
@@ -479,7 +488,7 @@ void MutationDispatcher::RecordSuccessfulMutationSequence() {
     assert(DE->GetW().size());
     // Linear search is fine here as this happens seldom.
     if (!PersistentAutoDictionary.ContainsWord(DE->GetW()))
-      PersistentAutoDictionary.push_back({DE->GetW(), 1});
+      PersistentAutoDictionary.push_back({DE->GetW(), {1, DE->GetW().size()}});
   }
 }
 
@@ -589,7 +598,7 @@ size_t MutationDispatcher::MutateWithMask(uint8_t *Data, size_t Size,
 
 void MutationDispatcher::AddWordToManualDictionary(const Word &W) {
   ManualDictionary.push_back(
-      {W, std::numeric_limits<size_t>::max()});
+      {W, PositionHint{std::numeric_limits<size_t>::max(), W.size()}});
 }
 
 }  // namespace fuzzer

--- a/compiler-rt/lib/fuzzer/FuzzerMutate.h
+++ b/compiler-rt/lib/fuzzer/FuzzerMutate.h
@@ -121,7 +121,7 @@ public:
   DictionaryEntry MakeDictionaryEntryFromCMP(const void *Arg1, const void *Arg2,
                                              const void *Arg1Mutation,
                                              const void *Arg2Mutation,
-                                             size_t ArgSize,
+                                             size_t Arg1Size, size_t Arg2Size,
                                              const uint8_t *Data, size_t Size);
 
   Random &Rand;

--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
@@ -100,7 +100,7 @@ class TracePC {
   void IterateCoveredFunctions(CallBack CB);
 
   void AddValueForMemcmp(void *caller_pc, const void *s1, const void *s2,
-                         size_t n, bool StopAtZero);
+                         size_t Len1, size_t Len2, bool StopAtZero);
 
   TableOfRecentCompares<uint32_t, 32> TORC4;
   TableOfRecentCompares<uint64_t, 32> TORC8;


### PR DESCRIPTION
Currently, the two string arguments to strcmp calls are truncated to the
length of the shorter of the two before they are inserted into the table
of recent compares.

With this commit, the two strings are recorded without truncation (up to
a maximum length of Word::GetMaxSize()) and any occurence of either of
the two can be replaced by the other via the TORCW-based mutator. To
make this possible, the concept of a position hint is extended to not
only contain the buffer position at which the string to be replaced has
been found in the input, but also the length of the string.